### PR TITLE
changes quote with backtick to support typescript string interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gulp.task('template', function() {
 	.pipe(html2ts())
   //.pipe(html2ts('app'))
   //.pipe(html2ts({ moduleName: '{$folderName}', propertyName: '{$fileName}Html'}))
-	.pipe(gulp.dest('./')); 
+	.pipe(gulp.dest('./'));
 });
 
 ```
@@ -30,12 +30,12 @@ Example
 
 This example shows how this plugin turn html into a ts file.
 
-*HTML Source* : `mytemplate.html`
+*HTML Source* : `views/my_template.html`
 ```html
   <p>A {{ handlebar }} example.</p>
 ```
 
-*The generated output* : `mytemplate.html.ts`
+*The generated output* : `my_template.html.ts`
 ```typescript
-module mytemplate { export var html = '<p>A {{ handlebar }} example.</p>';}
+module views { export var myTemplate = '<p>A {{ handlebar }} example.</p>';}
 ```

--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ This example shows how this plugin turn html into a ts file.
 
 *The generated output* : `my_template.html.ts`
 ```typescript
-module views { export var myTemplate = \`<p>A {{ handlebar }} example.</p>\`;}
+module views { export var myTemplate = `<p>A {{ handlebar }} example.</p>`;}
 ```

--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ This example shows how this plugin turn html into a ts file.
 
 *The generated output* : `my_template.html.ts`
 ```typescript
-module views { export var myTemplate = '<p>A {{ handlebar }} example.</p>';}
+module views { export var myTemplate = \`<p>A {{ handlebar }} example.</p>\`;}
 ```

--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ function stripBOM(str) {
         : str;
 }
 
+// Transforms string to camelcase, to save valid name variable
+function camelize(str) {
+  return str.replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
+    return index == 0 ? letter.toLowerCase() : letter.toUpperCase();
+  }).replace(/[-._\s]+/g, '');
+}
+
+
 function html2Ts(config){
 	var param = {};
 	config = config || {};
@@ -29,7 +37,7 @@ function html2Ts(config){
 		}
 
 
-		var fileName = path.basename(file.path, param.fileSrcType);
+		var fileName = camelize(path.basename(file.path, param.fileSrcType));
 		if(!fileName){
 			this.emit('error', new PluginError(PLUGIN_NAME, 'file <'+ file.path +'> not converted!'));
 			return done();

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function html2Ts(config){
 		}
 
 		var dirName = path.dirname(file.path);
-		var folderName = path.basename(dirName);
+		var folderName = camelize(path.basename(dirName));
 		var content = stripBOM(file.contents.toString());
 
 		content = param.tsTemplate

--- a/index.js
+++ b/index.js
@@ -7,20 +7,6 @@ var PluginError = gutil.PluginError;
 var PLUGIN_NAME = 'gulp-html-to-ts';
 
 // html -> js processing functions:
-// Originally from karma-html2js-preprocessor
-var escapeContent = function (content) {
-    var singleQuoteChar = '\'';
-	var singleQuoteRegexp = new RegExp('\\' + singleQuoteChar, 'g');
-
-    var doubleQuoteChar = '\"';
-	var doubleQuoteRegexp = new RegExp('\\' + doubleQuoteChar, 'g');
-	
-	return content
-		.replace(singleQuoteRegexp, '\\' + singleQuoteChar)
-		.replace(doubleQuoteRegexp, '\\' + doubleQuoteChar)
-		.replace(/\r?\n/g, " ");
-};
-
 // Remove bom when reading utf8 files
 function stripBOM(str) {
     return 0xFEFF === str.charCodeAt(0)
@@ -31,18 +17,18 @@ function stripBOM(str) {
 function html2Ts(config){
 	var param = {};
 	config = config || {};
-	
+
 	param.fileSrcType = config.fileSrcType || '.html';
 	param.fileDestType = config.fileDestType || '.ts';
-	param.tsTemplate =  config.tsTemplate || "module $folderName { export var $fileName = \'$fileContent\';}";
-		
+	param.tsTemplate =  config.tsTemplate || "module $folderName { export var $fileName = `$fileContent`;}";
+
 	return through.obj( function( file, enc, done ) {
 		if (file.isNull()) {
 			done(null, file); //empty file
 			return;
 		}
-		
-		
+
+
 		var fileName = path.basename(file.path, param.fileSrcType);
 		if(!fileName){
 			this.emit('error', new PluginError(PLUGIN_NAME, 'file <'+ file.path +'> not converted!'));
@@ -51,31 +37,31 @@ function html2Ts(config){
 
 		var dirName = path.dirname(file.path);
 		var folderName = path.basename(dirName);
-		var content = stripBOM(escapeContent(file.contents.toString()));
-		
+		var content = stripBOM(file.contents.toString());
+
 		content = param.tsTemplate
 			.replace("$folderName", folderName)
 			.replace("$fileName", fileName)
 			.replace('$fileContent', content);
-		
+
 		if( file.isStream() ) {
 			var stream = through();
 			stream.write(content);
-			
+
 			stream.on('error', this.emit.bind(this, 'error'));
-		      
+
 			file.contents = stream;
 		}
-		
+
 		if( file.isBuffer() ) {
 			file.contents = new Buffer( content );
 		}
 
 		file.path += param.fileDestType;
 		this.push( file );
-		
+
 		return done();
-	});	
+	});
 }
 
 module.exports = html2Ts;


### PR DESCRIPTION
I need to support typescript string interpolation for variables 
```${something}```
So I've changed that and I've removed the escape, that should be no more necessary with backtick notation

Tnx for the awesome work, I owe you a beer